### PR TITLE
Wrap the vim.notify call in pcall to avoid errors

### DIFF
--- a/lua/tip.lua
+++ b/lua/tip.lua
@@ -31,7 +31,7 @@ M.setup = function(params)
               res = 'Error fetching tip: ' .. res
             end
 
-            vim.notify(res, M.config.seconds, { title = M.config.title })
+            pcall(vim.notify, res, M.config.seconds, { title = M.config.title })
           end,
         })
         :start()


### PR DESCRIPTION
I randomly get an error from plenary mentioning something along the lines of "echo_msg should not be in a job" (something like that), or "dead coroutine".

The error is very annoying, specially since the plugin runs on startup. Wrapping the call in `pcall` avoids those errors in case they happen (not a huge deal if we miss a tip or two, and I think it's worth avoiding the error)

BTW, thank you for the great idea for the plugin. I really like it (hence the PRs 😆 )